### PR TITLE
Feature Update

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,7 +125,13 @@ func main() {
 //botConnected is a collection of code that is ran when the bot connects to the Discord API
 func botConnected(session *discordgo.Session, event *discordgo.Ready) {
 	//Updates Bot User Status
-	session.UpdateStatus(0, "Type "+cmdprefix+".help")
+	//*NOTE* Any code below this will *not* run make sure to put anything that needs to be ran once above this for loop
+	for 1 == 1 {
+		session.UpdateStatus(0, "Type "+cmdprefix+".help")
+		time.Sleep(6 * time.Second)
+		session.UpdateStatus(0, "with "+strconv.Itoa(len(session.State.Guilds))+" servers")
+		time.Sleep(6 * time.Second)
+	}
 }
 
 /*
@@ -154,26 +160,34 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 	//q.ping
 	if strings.HasPrefix(strings.ToLower(event.Content), cmdprefix+".ping") {
 		session.ChannelMessageDelete(event.ChannelID, event.Message.ID)
-		session.ChannelMessageSend(event.ChannelID, "Ping!")
+		sentMessage, _ := session.ChannelMessageSend(event.ChannelID, session.HeartbeatLatency().String())
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
 	//q.invite
 	if strings.HasPrefix(strings.ToLower(event.Content), cmdprefix+".invite") {
+		bulkDeleteSlice := []string{}
 		if devmode == true {
-			session.ChannelMessageSend(event.ChannelID, "Invite command disabled while running in Developer Mode!")
+			session.ChannelMessageDelete(event.ChannelID, event.Message.ID)
+			sentMessage, _ := session.ChannelMessageSend(event.ChannelID, "Invite command disabled while running in Developer Mode!")
+			bulkDeleteSlice = append(bulkDeleteSlice, sentMessage.ID)
 		} else {
 			privateChannel, err := session.UserChannelCreate(event.Author.ID)
 			if err != nil {
-				session.ChannelMessageSend(event.ChannelID, "Oh no, something went wrong!")
+				sentMessage, _ := session.ChannelMessageSend(event.ChannelID, "Oh no, something went wrong!")
+				bulkDeleteSlice = append(bulkDeleteSlice, sentMessage.ID)
 				fmt.Println(err)
 				return
 			}
 			session.MessageReactionAdd(event.ChannelID, event.Message.ID, "👍")
-			session.ChannelMessageSend(privateChannel.ID, "A hot invite link, fresh from the ovens!")
-			session.ChannelMessageSend(privateChannel.ID, "https://discordapp.com/oauth2/authorize?client_id=535127851653922816&permissions=3533888&scope=bot")
-			return
+			session.ChannelMessageSend(privateChannel.ID, "A hot invite link, fresh from the ovens!\nhttps://discordapp.com/oauth2/authorize?client_id=535127851653922816&permissions=3533888&scope=bot")
+			bulkDeleteSlice = append(bulkDeleteSlice, event.Message.ID)
 		}
+		time.Sleep(6 * time.Second)
+		session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
+		return
 	}
 
 	//q.info
@@ -215,7 +229,9 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				URL: "https://cdn.discordapp.com/avatars/535127851653922816/a6b1eb1cdcc29e0bd7e14228b17a28aa.png?size=512",
 			},
 		}
-		session.ChannelMessageSendEmbed(event.ChannelID, infoEmbed)
+		sentMessage, _ := session.ChannelMessageSendEmbed(event.ChannelID, infoEmbed)
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -234,7 +250,7 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				},
 				&discordgo.MessageEmbedField{
 					Name:   cmdprefix + ".ping",
-					Value:  "Replies with 'Ping!'",
+					Value:  "Replies with Discord API Latency",
 					Inline: false,
 				},
 				&discordgo.MessageEmbedField{
@@ -249,7 +265,9 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				},
 			},
 		}
-		session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		sentMessage, _ := session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -288,7 +306,9 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				},
 			},
 		}
-		session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		sentMessage, _ := session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -312,7 +332,9 @@ func basicCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				},
 			},
 		}
-		session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		sentMessage, _ := session.ChannelMessageSendEmbed(event.ChannelID, helpEmbed)
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 }
@@ -331,11 +353,13 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 
 		//Creates a Key for the requests to follow called 'userKey'
 		userKey := datastore.NameKey("User", event.Author.ID, nil)
+		user := UserStructure{}
+		var sentMessage *discordgo.Message
 
 		//Attempt to get an entity from the Datastore with the title of the User's Discord ID
 		//If it finds one it just tells the user they are already registered
 		//If it can not find one it creates one with the basic stats and then tells the user that they are now registered
-		if err := gcp.Get(ctx, userKey, nil); err != nil {
+		if err := gcp.Get(ctx, userKey, &user); err != nil {
 			user := UserStructure{
 				Attack:  4,
 				Defense: 4,
@@ -348,10 +372,14 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 				session.ChannelMessageSend(event.ChannelID, failureMessage)
 				return
 			}
-			session.ChannelMessageSend(event.ChannelID, "Registered!")
+			sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "Registered!")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
-		session.ChannelMessageSend(event.ChannelID, "You are already registered!")
+		sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "You are already registered!")
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -360,14 +388,16 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 		session.ChannelMessageDelete(event.ChannelID, event.Message.ID)
 
 		userKey := datastore.NameKey("User", event.Author.ID, nil)
+		var sentMessage *discordgo.Message
 		user := UserStructure{}
 
 		if err := gcp.Get(ctx, userKey, &user); err != nil {
 			fmt.Println("--Warning--")
 			fmt.Println("Failed to find user from GCP Datastore")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, "You are not registered!")
-			session.ChannelMessageSend(event.ChannelID, "Please run ``"+cmdprefix+".game.join``")
+			sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "You are not registered!\nPlease run ``"+cmdprefix+".game.join``")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
 
@@ -375,19 +405,22 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 			user.Credits = user.Credits - 10
 			user.Attack++
 		} else {
-			session.ChannelMessageSend(event.ChannelID, "You don't have enough credits!")
+			sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "You don't have enough credits!")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
-
-		session.ChannelMessageSend(event.ChannelID, "Success! Your attack is now level "+strconv.Itoa(user.Attack))
-		session.ChannelMessageSend(event.ChannelID, "You now have "+strconv.Itoa(user.Credits)+" credits left!")
 
 		if _, err := gcp.Put(ctx, userKey, &user); err != nil {
 			fmt.Println("--Error--")
 			fmt.Println("Failed to create GCP client")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, failureMessage)
+			session.ChannelMessageSend(event.ChannelID, "```"+failureMessage+"```\nPlease Contact OrangeFlare#1337")
+			return
 		}
+		sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "Success! Your attack is now level "+strconv.Itoa(user.Attack)+"\nYou now have "+strconv.Itoa(user.Credits)+" credits left!")
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -396,14 +429,16 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 		session.ChannelMessageDelete(event.ChannelID, event.Message.ID)
 
 		userKey := datastore.NameKey("User", event.Author.ID, nil)
+		var sentMessage *discordgo.Message
 		user := UserStructure{}
 
 		if err := gcp.Get(ctx, userKey, &user); err != nil {
 			fmt.Println("--Warning--")
 			fmt.Println("Failed to find user from GCP Datastore")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, "You are not registered!")
-			session.ChannelMessageSend(event.ChannelID, "Please run ``"+cmdprefix+".game.join``")
+			sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "You are not registered!\nPlease run ``"+cmdprefix+".game.join``")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
 
@@ -411,19 +446,22 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 			user.Credits = user.Credits - 10
 			user.Defense++
 		} else {
-			session.ChannelMessageSend(event.ChannelID, "You don't have enough credits!")
+			sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "You don't have enough credits!")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
-
-		session.ChannelMessageSend(event.ChannelID, "Success! Your defense is now level "+strconv.Itoa(user.Defense))
-		session.ChannelMessageSend(event.ChannelID, "You now have "+strconv.Itoa(user.Credits)+" credits left!")
 
 		if _, err := gcp.Put(ctx, userKey, &user); err != nil {
 			fmt.Println("--Error--")
 			fmt.Println("Failed to create GCP client")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, failureMessage)
+			session.ChannelMessageSend(event.ChannelID, "```"+failureMessage+"```\nPlease Contact OrangeFlare#1337")
+			return
 		}
+		sentMessage, _ = session.ChannelMessageSend(event.ChannelID, "Success! Your defense is now level "+strconv.Itoa(user.Defense)+"\nYou now have "+strconv.Itoa(user.Credits)+" credits left!")
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -438,8 +476,9 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 			fmt.Println("--Warning--")
 			fmt.Println("Failed to find user from GCP Datastore")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, "You are not registered!")
-			session.ChannelMessageSend(event.ChannelID, "Please run ``"+cmdprefix+".game.join``")
+			sentMessage, _ := session.ChannelMessageSend(event.ChannelID, "You are not registered!\nPlease run ``"+cmdprefix+".game.join``")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
 
@@ -470,7 +509,9 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 			},
 		}
 
-		session.ChannelMessageSendEmbed(event.Message.ChannelID, infoEmbed)
+		sentMessage, _ := session.ChannelMessageSendEmbed(event.Message.ChannelID, infoEmbed)
+		time.Sleep(6 * time.Second)
+		session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 		return
 	}
 
@@ -486,15 +527,16 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 			fmt.Println("--Warning--")
 			fmt.Println("Failed to find user from GCP Datastore")
 			fmt.Println(err)
-			session.ChannelMessageSend(event.ChannelID, "You are not registered!")
-			session.ChannelMessageSend(event.ChannelID, "Please run ``"+cmdprefix+".game.join``")
+			sentMessage, _ := session.ChannelMessageSend(event.ChannelID, "You are not registered!\nPlease run ``"+cmdprefix+".game.join``")
+			time.Sleep(6 * time.Second)
+			session.ChannelMessageDelete(event.ChannelID, sentMessage.ID)
 			return
 		}
 
 		rand.Seed(time.Now().UnixNano())
 		monster.Attack = int(float64(user.Attack) * ((0.7 + rand.Float64()) * 0.8))
 		monster.Defense = int(float64(user.Defense) * ((0.7 + rand.Float64()) * 0.8))
-		monster.Reward = int(float64(rand.Intn(4)+8) * ((float64(monster.Attack) + float64(monster.Defense)) / 4) * (0.05 + rand.Float64()*(0.20)))
+		monster.Reward = int(float64(rand.Intn(4)+9) * ((float64(monster.Attack) + float64(monster.Defense)) / 4) * (0.05 + rand.Float64()*(0.20)))
 		fightMonster(user, monster, event, session)
 	}
 
@@ -523,133 +565,121 @@ func gameCommands(session *discordgo.Session, event *discordgo.MessageCreate) {
 func fightMonster(user UserStructure, monster MonsterStructure, event *discordgo.MessageCreate, session *discordgo.Session) {
 	//HP is based off of Defense
 	rand.Seed(time.Now().UnixNano())
+	baseMonsterHP := monster.Defense
+	baseUserHP := user.Defense
+	bulkDeleteSlice := []string{}
 
-	monsterStats := &discordgo.MessageEmbed{
-		Color: 0xff0000, // red
-		Title: "Random Monster's Statistics",
-		Fields: []*discordgo.MessageEmbedField{
-			&discordgo.MessageEmbedField{
-				Name:   "Attack",
-				Value:  strconv.Itoa(monster.Attack),
-				Inline: true,
-			},
-			&discordgo.MessageEmbedField{
-				Name:   "Defense",
-				Value:  strconv.Itoa(monster.Defense),
-				Inline: true,
-			},
-			&discordgo.MessageEmbedField{
-				Name:   "Level",
-				Value:  strconv.Itoa(monster.Attack + monster.Defense),
-				Inline: true,
-			},
-		},
-	}
+	sentBattleStats, _ := session.ChannelMessageSendEmbed(event.ChannelID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
+	bulkDeleteSlice = append(bulkDeleteSlice, sentBattleStats.ID)
 
-	playerStats := &discordgo.MessageEmbed{
-		Color: 0x00ff00, // green
-		Title: event.Author.Username + "'s Statistics",
-		Fields: []*discordgo.MessageEmbedField{
-			&discordgo.MessageEmbedField{
-				Name:   "Attack",
-				Value:  strconv.Itoa(user.Attack),
-				Inline: true,
-			},
-			&discordgo.MessageEmbedField{
-				Name:   "Defense",
-				Value:  strconv.Itoa(user.Defense),
-				Inline: true,
-			},
-			&discordgo.MessageEmbedField{
-				Name:   "Level",
-				Value:  strconv.Itoa(user.Attack + user.Defense),
-				Inline: true,
-			},
-		},
-	}
+	sentBattleLog, _ := session.ChannelMessageSend(event.ChannelID, "Firing up the battle engines!")
+	bulkDeleteSlice = append(bulkDeleteSlice, sentBattleLog.ID)
 
-	session.ChannelMessageSend(event.ChannelID, event.Author.Username+" vs Random Monster!")
-	session.ChannelMessageSendEmbed(event.ChannelID, playerStats)
-	session.ChannelMessageSendEmbed(event.ChannelID, monsterStats)
-
-	if rand.Intn(1) == 1 {
+	//Battle Log Messages & End Status Event Handling
+	if rand.Intn(2) == 1 {
 		for user.Defense > 0 && monster.Defense > 0 {
-			bulkDeleteSlice := []string{}
-
-			var userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 4
+			crit := rand.Intn(20) + 1
+			var userDamage int
+			var critText string
+			if crit == 20 {
+				userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 3
+				critText = "*"
+			} else {
+				userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 4
+				critText = ""
+			}
 			monster.Defense = monster.Defense - userDamage
 			if monster.Defense > 0 {
-				sentMessageContent, err := session.ChannelMessageSend(event.ChannelID, "``"+event.Author.Username+" dealt "+strconv.Itoa(userDamage)+" damage to the enemy!``\n``The enemy has "+strconv.Itoa(monster.Defense)+"hp left!``")
-				bulkDeleteSlice = append(bulkDeleteSlice, sentMessageContent.ID)
-				if err != nil {
-					return
-				}
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``"+event.Author.Username+" dealt "+critText+strconv.Itoa(userDamage)+" damage"+critText+" to the enemy!``\n``The enemy has "+strconv.Itoa(monster.Defense)+"hp left!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 			} else {
-				session.ChannelMessageSend(event.ChannelID, "``"+event.Author.Username+" dealt "+strconv.Itoa(userDamage)+" damage to the enemy!``\n``The enemy has been slain!``")
+				monster.Defense = 0
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``"+event.Author.Username+" dealt "+critText+strconv.Itoa(userDamage)+" damage"+critText+" to the enemy!``\n``The enemy has been slain!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 				addCredits(event, session, event.Author.ID, monster.Reward)
-				session.ChannelMessageSend(event.ChannelID, "Your account has been credited "+strconv.Itoa(monster.Reward)+" Credits!")
-				return
+				sentBattleResult, _ := session.ChannelMessageSend(event.ChannelID, "Your account has been credited "+strconv.Itoa(monster.Reward)+" Credits!")
+				bulkDeleteSlice = append(bulkDeleteSlice, sentBattleResult.ID)
+				break
 			}
 			time.Sleep(2 * time.Second)
-			session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
-
-			var monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 4
+			crit = rand.Intn(20) + 1
+			var monsterDamage int
+			if crit == 20 {
+				monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 3
+				critText = "*"
+			} else {
+				monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 4
+				critText = ""
+			}
 			user.Defense = user.Defense - monsterDamage
 			if user.Defense > 0 {
-				sentMessageContent, err := session.ChannelMessageSend(event.ChannelID, "``The monster dealt "+strconv.Itoa(monsterDamage)+" damage to "+event.Author.Username+"!``\n``"+event.Author.Username+" has "+strconv.Itoa(user.Defense)+"hp left!``")
-				bulkDeleteSlice = append(bulkDeleteSlice, sentMessageContent.ID)
-				if err != nil {
-					return
-				}
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``The monster dealt "+critText+strconv.Itoa(monsterDamage)+" damage"+critText+" to "+event.Author.Username+"!``\n``"+event.Author.Username+" has "+strconv.Itoa(user.Defense)+"hp left!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 			} else {
-				session.ChannelMessageSend(event.ChannelID, "``The monster dealt "+strconv.Itoa(monsterDamage)+" damage to "+event.Author.Username+"!``\n``"+event.Author.Username+" has been slain!``")
+				user.Defense = 0
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``The monster dealt "+critText+strconv.Itoa(monsterDamage)+" damage"+critText+" to "+event.Author.Username+"!``\n``"+event.Author.Username+" has been slain!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 				removeCredits(event, session, event.Author.ID, monster.Reward/5)
-				session.ChannelMessageSend(event.ChannelID, "The monster has taken "+strconv.Itoa(monster.Reward/5)+" Credits from you!")
-				return
+				sentBattleResult, _ := session.ChannelMessageSend(event.ChannelID, "The monster has taken "+strconv.Itoa(monster.Reward/5)+" Credits from you!")
+				bulkDeleteSlice = append(bulkDeleteSlice, sentBattleResult.ID)
+				break
 			}
 			time.Sleep(2 * time.Second)
-			session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
 		}
 	} else {
 		for user.Defense > 0 && monster.Defense > 0 {
-			bulkDeleteSlice := []string{}
-
-			var monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 4
+			crit := rand.Intn(20) + 1
+			var monsterDamage int
+			var critText string
+			if crit == 20 {
+				monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 3
+				critText = "*"
+			} else {
+				monsterDamage = int(float64(monster.Attack)*(0.8+rand.Float64()*0.4)) / 4
+				critText = ""
+			}
 			user.Defense = user.Defense - monsterDamage
 			if user.Defense > 0 {
-				sentMessageContent, err := session.ChannelMessageSend(event.ChannelID, "``The monster dealt "+strconv.Itoa(monsterDamage)+" damage to "+event.Author.Username+"!``\n``"+event.Author.Username+" has "+strconv.Itoa(user.Defense)+"hp left!``")
-				bulkDeleteSlice = append(bulkDeleteSlice, sentMessageContent.ID)
-				if err != nil {
-					return
-				}
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``The monster dealt "+critText+strconv.Itoa(monsterDamage)+" damage"+critText+" to "+event.Author.Username+"!``\n``"+event.Author.Username+" has "+strconv.Itoa(user.Defense)+"hp left!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 			} else {
-				session.ChannelMessageSend(event.ChannelID, "``The monster dealt "+strconv.Itoa(monsterDamage)+" damage to "+event.Author.Username+"!``\n``"+event.Author.Username+" has been slain!``")
+				user.Defense = 0
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``The monster dealt "+critText+strconv.Itoa(monsterDamage)+" damage"+critText+" to "+event.Author.Username+"!``\n``"+event.Author.Username+" has been slain!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 				removeCredits(event, session, event.Author.ID, monster.Reward/5)
-				session.ChannelMessageSend(event.ChannelID, "The monster has taken "+strconv.Itoa(monster.Reward/5)+" Credits from you!")
-				return
+				sentBattleResult, _ := session.ChannelMessageSend(event.ChannelID, "The monster has taken "+strconv.Itoa(monster.Reward/5)+" Credits from you!")
+				bulkDeleteSlice = append(bulkDeleteSlice, sentBattleResult.ID)
+				break
 			}
 			time.Sleep(2 * time.Second)
-			session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
-
-			var userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 4
+			crit = rand.Intn(20) + 1
+			var userDamage int
+			if crit == 20 {
+				userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 3
+				critText = "*"
+			} else {
+				userDamage = int(float64(user.Attack)*(0.8+rand.Float64()*0.4)) / 4
+				critText = ""
+			}
 			monster.Defense = monster.Defense - userDamage
 			if monster.Defense > 0 {
-				sentMessageContent, err := session.ChannelMessageSend(event.ChannelID, "``"+event.Author.Username+" dealt "+strconv.Itoa(userDamage)+" damage to the enemy!``\n``The enemy has "+strconv.Itoa(monster.Defense)+"hp left!``")
-				bulkDeleteSlice = append(bulkDeleteSlice, sentMessageContent.ID)
-				if err != nil {
-					return
-				}
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``"+event.Author.Username+" dealt "+critText+strconv.Itoa(userDamage)+" damage"+critText+" to the enemy!``\n``The enemy has "+strconv.Itoa(monster.Defense)+"hp left!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 			} else {
-				session.ChannelMessageSend(event.ChannelID, "``"+event.Author.Username+" dealt "+strconv.Itoa(userDamage)+" damage to the enemy!``\n``The enemy has been slain!``")
+				monster.Defense = 0
+				session.ChannelMessageEdit(event.ChannelID, sentBattleLog.ID, "``"+event.Author.Username+" dealt "+critText+strconv.Itoa(userDamage)+" damage"+critText+" to the enemy!``\n``The enemy has been slain!``")
+				session.ChannelMessageEditEmbed(event.ChannelID, sentBattleStats.ID, battleStatsEmbed(event, session, user, monster, baseMonsterHP, baseUserHP))
 				addCredits(event, session, event.Author.ID, monster.Reward)
-				session.ChannelMessageSend(event.ChannelID, "Your account has been credited "+strconv.Itoa(monster.Reward)+" Credits!")
-				return
+				sentBattleResult, _ := session.ChannelMessageSend(event.ChannelID, "Your account has been credited "+strconv.Itoa(monster.Reward)+" Credits!")
+				bulkDeleteSlice = append(bulkDeleteSlice, sentBattleResult.ID)
+				break
 			}
 			time.Sleep(2 * time.Second)
-			session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
 		}
 	}
-
+	time.Sleep(10 * time.Second)
+	session.ChannelMessagesBulkDelete(event.ChannelID, bulkDeleteSlice)
+	return
 }
 
 //addCredits contains all code for adding credits to a user
@@ -677,6 +707,51 @@ func addCredits(event *discordgo.MessageCreate, session *discordgo.Session, User
 		session.ChannelMessageSend(event.ChannelID, failureMessage)
 	}
 	return
+}
+
+func battleStatsEmbed(event *discordgo.MessageCreate, session *discordgo.Session, user UserStructure, monster MonsterStructure, baseMonsterHP int, baseUserHP int) *discordgo.MessageEmbed {
+	battleStats := &discordgo.MessageEmbed{
+		Color:       0xfaa61a, //quarkyellow
+		Title:       "Battle Statistics",
+		Description: "Let's get a quick overview of the battle!",
+		Fields: []*discordgo.MessageEmbedField{
+			&discordgo.MessageEmbedField{
+				Name:   "Player's Attack",
+				Value:  strconv.Itoa(user.Attack),
+				Inline: true,
+			},
+			&discordgo.MessageEmbedField{
+				Name:   "Player's Defense/HP",
+				Value:  strconv.Itoa(user.Defense) + "/" + strconv.Itoa(baseUserHP),
+				Inline: true,
+			},
+			&discordgo.MessageEmbedField{
+				Name:   "Player's Level",
+				Value:  strconv.Itoa(user.Attack + baseUserHP),
+				Inline: true,
+			},
+			&discordgo.MessageEmbedField{
+				Name:   "Monster's Attack",
+				Value:  strconv.Itoa(monster.Attack),
+				Inline: true,
+			},
+			&discordgo.MessageEmbedField{
+				Name:   "Monster's Defense/HP",
+				Value:  strconv.Itoa(monster.Defense) + "/" + strconv.Itoa(baseMonsterHP),
+				Inline: true,
+			},
+			&discordgo.MessageEmbedField{
+				Name:   "Monster's level",
+				Value:  strconv.Itoa(monster.Attack + baseMonsterHP),
+				Inline: true,
+			},
+		},
+		Footer: &discordgo.MessageEmbedFooter{
+			Text:    "Quark",
+			IconURL: "https://cdn.discordapp.com/avatars/535127851653922816/a6b1eb1cdcc29e0bd7e14228b17a28aa.png?size=64",
+		},
+	}
+	return battleStats
 }
 
 //takeCredits contains all code for removing credits from a user


### PR DESCRIPTION
Delete's Messages After 6 Seconds of Being Sent
New 'graphics' for the fight command
q.ping now replies with discord latency
Instead of sending 2 messages we now only send one with a new line to use up less CPU and so discord receives less API Hits
Fixed Critical Bug which allowed users to reset account with q.game.join
Added critical attack chances to the game
Fixed Random Number generation for selecting who goes first, and how the monster reward is generated